### PR TITLE
Refactor /status endpoint to use ISO-8601 date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ GET http://localhost:8080/status
 ```
 ```json
 {
-  status: "OK",
-  time: "2015-03-24T16:15:14Z"
+  "status": "OK",
+  "time": "2015-03-24T21:03:51.244Z"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,27 +23,53 @@ We encourage forking, adding to the code base and/or general use of the service.
 
 ## Dependencies
 
-Grasshopper needs [Elasticsearch](http://www.elasticsearch.org/) as a backend to store data for geocoding. 
-The services layer runs on the Java Virtual Machine (JVM). The project is being built and tested on JDK 8, but JDK 7 and OpenJDK versions 7 and 8 should also work. 
+### Java JDK
+The services layer runs on the Java Virtual Machine (JVM). The project is being built and 
+tested on [Oracle JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
+See [Oracle's JDK Install Overview](http://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html) 
+for install instructions.
 
-Describe any dependencies that must be installed for this software to work. 
-This includes programming languages, databases or other storage mechanisms, build tools, frameworks, and so forth.
-If specific versions of other software are required, or known not to work, call that out.
+Oracle JDK 7 and OpenJDK versions 7 and 8 should also work.
+
+### Scala
+To build the project, `sbt` is required. Please refer to the 
+[installation instructions](http://www.scala-sbt.org/0.13/tutorial/Setup.html) for your platform
+
+### Elasticsearch
+Grasshopper uses [Elasticsearch](http://www.elasticsearch.org/) as a backend to store data for geocoding. 
+
 
 ## Building
-
-To build the project, `sbt` is required. Please refer to the [installation instructions](http://www.scala-sbt.org/0.13/tutorial/Setup.html) for your platform
-
-Grasshopper is a multi-module sbt project, each project has a specific task and usually represents a [Microservice](http://en.wikipedia.org/wiki/Microservices).
-
-Once installed, from the project directory run the following:
+Grasshopper is a multi-module sbt project, each project has a specific task and usually represents 
+a [Microservice](http://en.wikipedia.org/wiki/Microservices).
 
 ```
 $ sbt
 > ~re-start
 ```
 
-This will fork a JVM and start the geocoding service. Currently the addresspoints project will expose a REST API to resolve addresses to locations in GeoJSON.
+This will fork a JVM and start the geocoding service. Currently the addresspoints project will expose 
+a REST API to resolve addresses to locations in GeoJSON.
+
+### Endpoints
+
+To confirm the service is running, you can test the following 
+
+1. Status
+
+```
+GET http://localhost:8080/status
+
+{
+  status: "OK",
+  time: "2015-03-24T16:15:14Z"
+}
+```
+
+2. Point - Single
+
+3. Point - Bulk
+
 
 
 ## How to test the software
@@ -66,7 +92,6 @@ The tests will print out a stack trace, the in memory Elasticsearch node doesn't
 
 For details on how to get involved, please first read our [CONTRIBUTING](CONTRIBUTING.md) guidelines.
 
-----
 
 ## Open source licensing info
 1. [TERMS](TERMS.md)

--- a/README.md
+++ b/README.md
@@ -63,15 +63,15 @@ Once running locally, the following endpoints should be available
 
 1. Status
 
-```
-GET http://localhost:8080/status
-```
-```json
-{
-  "status": "OK",
-  "time": "2015-03-24T21:03:51.244Z"
-}
-```
+    ```
+    GET http://localhost:8080/status
+    ```
+    ```json
+    {
+      "status": "OK",
+      "time": "2015-03-24T21:03:51.244Z"
+    }
+    ```
 
 ## Testing 
 

--- a/README.md
+++ b/README.md
@@ -23,25 +23,31 @@ We encourage forking, adding to the code base and/or general use of the service.
 
 ## Dependencies
 
-### Java JDK
-The services layer runs on the Java Virtual Machine (JVM). The project is being built and 
-tested on [Oracle JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
+### Java 8 JDK
+Grasshopper's service layer runs on the Java Virtual Machine (JVM), and requires the Java 8 JDK to build the project.
+This project is currenly being built and tested on [Oracle JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
 See [Oracle's JDK Install Overview](http://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html) 
 for install instructions.
 
-Oracle JDK 7 and OpenJDK versions 7 and 8 should also work.
+Grasshopper _should_ also run on OpenJDK 8, but has not been tested.
 
 ### Scala
-To build the project, `sbt` is required. Please refer to the 
-[installation instructions](http://www.scala-sbt.org/0.13/tutorial/Setup.html) for your platform
+Grasshopper's service layer is written in [Scala](http://www.scala-lang.org/).  You will need to 
+[download](http://www.scala-lang.org/download/) and [install]() Scala 2.11.x
+
+In addition, you'll need Scala's interactive build tool [sbt](http://www.scala-sbt.org/0.13/tutorial/index.html).
+Please refer to the [installation instructions](http://www.scala-sbt.org/0.13/tutorial/Setup.html) to get going.
 
 ### Elasticsearch
-Grasshopper uses [Elasticsearch](http://www.elasticsearch.org/) as a backend to store data for geocoding. 
+Grasshopper uses [Elasticsearch](http://www.elasticsearch.org/) as a backend to store data for geocoding.
+For dev and test purposes, grasshopper includes an in-memory
+[ElasticsearchServer](https://github.com/cfpb/grasshopper/blob/master/elasticsearch/src/main/scala/ElasticsearchServer.scala).
+For non-dev environments, you'll want a dedicated Elasticsearch instance.
 
 
 ## Building
-Grasshopper is a multi-module sbt project, each project has a specific task and usually represents 
-a [Microservice](http://en.wikipedia.org/wiki/Microservices).
+Grasshopper uses [sbt's multi-project builds](http://www.scala-sbt.org/0.13/tutorial/Multi-Project.html), 
+each project representing a specific task and usually a [Microservice](http://en.wikipedia.org/wiki/Microservices).
 
 ```
 $ sbt
@@ -51,28 +57,23 @@ $ sbt
 This will fork a JVM and start the geocoding service. Currently the addresspoints project will expose 
 a REST API to resolve addresses to locations in GeoJSON.
 
-### Endpoints
+## Usage
 
-To confirm the service is running, you can test the following 
+Once running locally, the following endpoints should be available 
 
 1. Status
 
 ```
 GET http://localhost:8080/status
-
+```
+```json
 {
   status: "OK",
   time: "2015-03-24T16:15:14Z"
 }
 ```
 
-2. Point - Single
-
-3. Point - Bulk
-
-
-
-## How to test the software
+## Testing 
 
 To run the tests, from the project directory: 
 

--- a/addresspoints/src/main/scala/addresspoints/api/Service.scala
+++ b/addresspoints/src/main/scala/addresspoints/api/Service.scala
@@ -1,8 +1,7 @@
 package addresspoints.api
 
-import java.text.SimpleDateFormat
-import java.time.{ ZoneOffset, LocalDateTime, ZoneId }
-import java.util.{ TimeZone, Date, Calendar }
+import java.time.Instant
+
 import addresspoints.model.{ AddressInput, Status }
 import addresspoints.protocol.JsonProtocol
 import akka.actor.ActorSystem
@@ -17,7 +16,7 @@ import com.typesafe.config.Config
 import grasshopper.elasticsearch.Geocode
 import org.elasticsearch.client.Client
 import scala.concurrent.ExecutionContextExecutor
-import scala.util.{ Try, Failure, Success }
+import scala.util.{ Failure, Success }
 import spray.json._
 import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory
@@ -42,7 +41,8 @@ trait Service extends JsonProtocol with Geocode {
       get {
         compressResponseIfRequested() {
           complete {
-            val now = formatIso8601(new Date())
+            // Creates ISO-8601 date string in UTC down to millisecond precision
+            val now = Instant.now.toString
             val status = Status("OK", now)
             log.info(status.toJson.toString())
             ToResponseMarshallable(status)
@@ -88,16 +88,6 @@ trait Service extends JsonProtocol with Geocode {
           NotFound
         }
     }
-  }
-
-  /**
-   * Translates a [[java.util.Date]] into ISO-8601 formatted with UTC timezone
-   */
-  private def formatIso8601(date: Date): String = {
-    val utc = TimeZone.getTimeZone("UTC")
-    val iso8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
-    iso8601.setTimeZone(utc)
-    iso8601.format(date)
   }
 
 }

--- a/addresspoints/src/main/scala/addresspoints/api/Service.scala
+++ b/addresspoints/src/main/scala/addresspoints/api/Service.scala
@@ -1,6 +1,8 @@
 package addresspoints.api
 
-import java.util.Calendar
+import java.text.SimpleDateFormat
+import java.time.{ ZoneOffset, LocalDateTime, ZoneId }
+import java.util.{ TimeZone, Date, Calendar }
 import addresspoints.model.{ AddressInput, Status }
 import addresspoints.protocol.JsonProtocol
 import akka.actor.ActorSystem
@@ -40,8 +42,8 @@ trait Service extends JsonProtocol with Geocode {
       get {
         compressResponseIfRequested() {
           complete {
-            val now = Calendar.getInstance().getTime()
-            val status = Status("OK", now.toString)
+            val now = formatIso8601(new Date())
+            val status = Status("OK", now)
             log.info(status.toJson.toString())
             ToResponseMarshallable(status)
           }
@@ -87,4 +89,15 @@ trait Service extends JsonProtocol with Geocode {
         }
     }
   }
+
+  /**
+   * Translates a [[java.util.Date]] into ISO-8601 formatted with UTC timezone
+   */
+  private def formatIso8601(date: Date): String = {
+    val utc = TimeZone.getTimeZone("UTC")
+    val iso8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+    iso8601.setTimeZone(utc)
+    iso8601.format(date)
+  }
+
 }

--- a/addresspoints/src/test/scala/AddressPointServiceSpec.scala
+++ b/addresspoints/src/test/scala/AddressPointServiceSpec.scala
@@ -1,5 +1,6 @@
 package grasshopper.addresspoints
 
+import java.text.SimpleDateFormat
 import addresspoints.api.Service
 import addresspoints.model
 import addresspoints.model.AddressInput
@@ -49,7 +50,13 @@ class AddressPointServiceSpec extends FlatSpec with MustMatchers with ScalatestR
       status mustBe OK
       contentType.mediaType mustBe `application/json`
       val resp = responseAs[model.Status]
+
+      // Test for correct "status"
       resp.status mustBe "OK"
+
+      // Test that "time" is correctly formatted
+      val iso8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+      resp.time mustBe iso8601.format(iso8601.parse(resp.time))
     }
   }
 

--- a/addresspoints/src/test/scala/AddressPointServiceSpec.scala
+++ b/addresspoints/src/test/scala/AddressPointServiceSpec.scala
@@ -1,6 +1,8 @@
 package grasshopper.addresspoints
 
-import java.text.SimpleDateFormat
+import java.time.temporal.TemporalUnit
+import java.time.{ Duration, Instant }
+
 import addresspoints.api.Service
 import addresspoints.model
 import addresspoints.model.AddressInput
@@ -54,9 +56,10 @@ class AddressPointServiceSpec extends FlatSpec with MustMatchers with ScalatestR
       // Test for correct "status"
       resp.status mustBe "OK"
 
-      // Test that "time" is correctly formatted
-      val iso8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
-      resp.time mustBe iso8601.format(iso8601.parse(resp.time))
+      // Test that "time" is formatted correctly, and close to current time (1 sec.)
+      val statusTime = Instant.parse(resp.time)
+      val timeDiff = Duration.between(statusTime, Instant.now).getSeconds
+      timeDiff must be <= 1l
     }
   }
 


### PR DESCRIPTION
Resolves #33

One slight change from what was proposed on #33.  When I refactored to use Java 8 Date & Time API, I came across `Instance.now()` which returns an ISO-8601 date in UTC with _millisecond_ precision.  Since I was able to get _almost_ exactly what we want with just a single line of code, I decided to just keep it that way.

Also includes a bit of reworking on README.md to indicate we're Java 8 only now...and some other clarifications.
