### PR TITLE
BadRequest test for invalid JSON POSTed to /addresses/points endpoint

### DIFF
--- a/addresspoints/src/test/scala/AddressPointServiceSpec.scala
+++ b/addresspoints/src/test/scala/AddressPointServiceSpec.scala
@@ -79,6 +79,13 @@ class AddressPointServiceSpec extends FlatSpec with MustMatchers with ScalatestR
     }
   }
 
+  it should "return BadRequest when invalid JSON is POSTed" in {
+    val badJson = """{"invalid":"json"}"""
+    Post("/addresses/points", HttpEntity(ContentTypes.`application/json`, badJson)) ~> routes ~> check(
+      status mustBe BadRequest
+    )
+  }
+
   it should "geocode a single point" in {
     val address = AddressInput("1311 30th St NW Washington DC 20007")
     val json = address.toJson.toString


### PR DESCRIPTION
Resolves #34.
