### PR TITLE
Adds Google's cAdvisor to Docker Compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ loader:
 # Must be named "elasticsearch" to create expected ELASTICSEARCH_* envvars
 elasticsearch:
   image: elasticsearch
+
 ui:
   build: ../grasshopper-ui
   ports:
@@ -59,4 +60,14 @@ ui:
     - lines
     - points
     - parser
+
+cadvisor:
+  image: google/cadvisor
+  ports:
+    - "9090:8080"
+  volumes:
+    - /:/rootfs:ro
+    - /var/run:/var/run:rw
+    - /sys:/sys:ro
+    - /var/lib/docker/:/var/lib/docker:ro
 


### PR DESCRIPTION
As discussed on https://github.com/cfpb/grasshopper/issues/106#issuecomment-109043591, this adds Google's [cAdvisor]() to the Docker Compose setup.  To access the cAdvisor webapp, just browse to `http://{{boot2docker-ip}}:9090`.
