### PR TITLE
Adds Dockerized Logspout & ELK Stack

### DIFF
--- a/addresspoints/src/main/resources/logback.xml
+++ b/addresspoints/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/addresspoints/src/main/resources/logback.xml
+++ b/addresspoints/src/main/resources/logback.xml
@@ -1,23 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <!-- encoders are assigned the type
-             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>[%d][%-5level][%thread] %msg%n</pattern>
         </encoder>
     </appender>
 
-    <appender name="logstash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-        <!-- remoteHost and port are optional (default values shown) -->
-        <remoteHost>${LOGSTASH_HOST:-localhost}</remoteHost>
-        <port>${LOGSTASH_PORT:-9001}</port>
-
-        <!-- encoder is required -->
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <root level="INFO">
-        <appender-ref ref="logstash" />
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
     </root>
+
 </configuration>

--- a/census/src/main/resources/logback.xml
+++ b/census/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/census/src/main/resources/logback.xml
+++ b/census/src/main/resources/logback.xml
@@ -1,23 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <!-- encoders are assigned the type
-             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>[%d][%-5level][%thread] %msg%n</pattern>
         </encoder>
     </appender>
 
-    <appender name="logstash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-        <!-- remoteHost and port are optional (default values shown) -->
-        <remoteHost>${LOGSTASH_HOST:-localhost}</remoteHost>
-        <port>${LOGSTASH_PORT:-9001}</port>
-
-        <!-- encoder is required -->
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <root level="INFO">
-        <appender-ref ref="logstash" />
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
     </root>
+
 </configuration>

--- a/client/src/main/resources/logback.xml
+++ b/client/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/client/src/main/resources/logback.xml
+++ b/client/src/main/resources/logback.xml
@@ -1,23 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <!-- encoders are assigned the type
-             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>[%d][%-5level][%thread] %msg%n</pattern>
         </encoder>
     </appender>
 
-    <appender name="logstash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-        <!-- remoteHost and port are optional (default values shown) -->
-        <remoteHost>${LOGSTASH_HOST:-localhost}</remoteHost>
-        <port>${LOGSTASH_PORT:-9001}</port>
-
-        <!-- encoder is required -->
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <root level="INFO">
-        <appender-ref ref="logstash" />
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
     </root>
+
 </configuration>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,27 +91,7 @@ logstash:
     - elasticsearch
   command: >
     logstash -e '
-    input { tcp { port => 5514 type => syslog } udp { port => 5514 type => syslog } } 
-    filter {
-      if [type] == "syslog" {
-        grok {
-          match => { "message" => "%{SYSLOG5424PRI}%{NONNEGINT:ver} +(?:%{TIMESTAMP_ISO8601:ts}|-) +(?:%{HOSTNAME:containerid}|-) +(?:%{NOTSPACE:containername}|-) +(?:%{NOTSPACE:proc}|-) +(?:%{WORD:msgid}|-) +(?:%{SYSLOG5424SD:sd}|-|) +%{GREEDYDATA:msg}" }
-        }
-        syslog_pri { }
-        date {
-          match => [ "syslog_timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss" ]
-        }
-        if !("_grokparsefailure" in [tags]) {
-          mutate {
-            replace => [ "@source_host", "%{syslog_hostname}" ]
-            replace => [ "@message", "%{syslog_message}" ]
-          }
-        }
-        mutate {
-          remove_field => [ "syslog_hostname", "syslog_message", "syslog_timestamp" ]
-        }
-      }
-    }
+    input { syslog{ port => 5514 } } 
     output { elasticsearch { host => "elasticsearch" } }'
 
 kibana:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,3 +71,53 @@ cadvisor:
     - /sys:/sys:ro
     - /var/lib/docker/:/var/lib/docker:ro
 
+# Logspout setup taken from:
+#   https://github.com/gliderlabs/logspout#route-all-container-output-to-remote-syslog
+logspout:
+  image: gliderlabs/logspout
+  ports:
+    - "8000:8000"
+  volumes: 
+    - /var/run/docker.sock:/tmp/docker.sock
+  links:
+    - logstash
+  command: syslog://logstash:5514
+
+logstash:
+  image: logstash
+  expose:
+    - 5514
+  links:
+    - elasticsearch
+  command: >
+    logstash -e '
+    input { tcp { port => 5514 type => syslog } udp { port => 5514 type => syslog } } 
+    filter {
+      if [type] == "syslog" {
+        grok {
+          match => { "message" => "%{SYSLOG5424PRI}%{NONNEGINT:ver} +(?:%{TIMESTAMP_ISO8601:ts}|-) +(?:%{HOSTNAME:containerid}|-) +(?:%{NOTSPACE:containername}|-) +(?:%{NOTSPACE:proc}|-) +(?:%{WORD:msgid}|-) +(?:%{SYSLOG5424SD:sd}|-|) +%{GREEDYDATA:msg}" }
+        }
+        syslog_pri { }
+        date {
+          match => [ "syslog_timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss" ]
+        }
+        if !("_grokparsefailure" in [tags]) {
+          mutate {
+            replace => [ "@source_host", "%{syslog_hostname}" ]
+            replace => [ "@message", "%{syslog_message}" ]
+          }
+        }
+        mutate {
+          remove_field => [ "syslog_hostname", "syslog_message", "syslog_timestamp" ]
+        }
+      }
+    }
+    output { elasticsearch { host => "elasticsearch" } }'
+
+kibana:
+  image: marcbachmann/kibana4
+  links:
+    - elasticsearch
+  ports:
+    - "5601:5601"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,13 +74,16 @@ cadvisor:
 # Logspout setup taken from:
 #   https://github.com/gliderlabs/logspout#route-all-container-output-to-remote-syslog
 logspout:
-  image: gliderlabs/logspout
+  image: gliderlabs/logspout:master 
   ports:
     - "8000:8000"
   volumes: 
     - /var/run/docker.sock:/tmp/docker.sock
   links:
     - logstash
+  environment:
+    LOGSPOUT: ignore
+    SYSLOG_FORMAT: rfc3164
   command: syslog://logstash:5514
 
 logstash:
@@ -89,13 +92,25 @@ logstash:
     - 5514
   links:
     - elasticsearch
+  environment:
+    LOGSPOUT: ignore
   command: >
     logstash -e '
-    input { syslog{ port => 5514 } } 
+    input { syslog{ port => 5514 } }
+    filter { 
+        grok { 
+          match => { "message" => [
+            "%{IP:http_client_ip} - - \[%{HTTPDATE:http_req_time}\] (.)%{WORD:http_req_method} %{URIPATH:uri_path}(?:%{URIPARAM:uri_params})? HTTP\/%{NUMBER:http_ver}(.) %{NUMBER:http_resp_code} %{NUMBER:http_resp_size} (.)-(.) (.)%{GREEDYDATA:http_client}(.)"
+          ] }
+        }
+        kv { source => "uri_params" prefix => "uri_param_" field_split => "&?" }
+    }
     output { elasticsearch { host => "elasticsearch" } }'
 
 kibana:
   image: marcbachmann/kibana4
+  environment:
+    LOGSPOUT: ignore
   links:
     - elasticsearch
   ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,8 +100,11 @@ logstash:
     filter { 
         grok { 
           match => { "message" => [
-            "%{IP:http_client_ip} - - \[%{HTTPDATE:http_req_time}\] (.)%{WORD:http_req_method} %{URIPATH:uri_path}(?:%{URIPARAM:uri_params})? HTTP\/%{NUMBER:http_ver}(.) %{NUMBER:http_resp_code} %{NUMBER:http_resp_size} (.)-(.) (.)%{GREEDYDATA:http_client}(.)"
+            "%{IP:http_client_ip} - - \[%{HTTPDATE:http_req_time}\] (.)%{WORD:http_req_method} %{URIPATH:uri_path}(?:%{URIPARAM:uri_params})? HTTP\/%{NUMBER:http_ver}(.) %{NUMBER:http_resp_code} %{NUMBER:http_resp_size} (.)-(.) (.)%{GREEDYDATA:http_client}(.)",
+            "\[%{TIMESTAMP_ISO8601:log_time}\]\[%{LOGLEVEL:log_level}%{SPACE}\]\[%{DATA:log_source}%{SPACE}\]%{SPACE}\[%{DATA:es_node}\]%{SPACE}\[%{DATA:es_index}\]%{SPACE}%{GREEDYDATA:message}",
+            "\[%{TIMESTAMP_ISO8601:log_time}\]\[%{LOGLEVEL:log_level}%{SPACE}\]\[%{DATA:thread_name}\]%{SPACE}%{GREEDYDATA:message}"
           ] }
+          overwrite => ["message"]
         }
         kv { source => "uri_params" prefix => "uri_param_" field_split => "&?" }
     }

--- a/geocoder/src/main/resources/logback.xml
+++ b/geocoder/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/geocoder/src/main/resources/logback.xml
+++ b/geocoder/src/main/resources/logback.xml
@@ -1,23 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <!-- encoders are assigned the type
-             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>[%d][%-5level][%thread] %msg%n</pattern>
         </encoder>
     </appender>
 
-    <appender name="logstash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-        <!-- remoteHost and port are optional (default values shown) -->
-        <remoteHost>${LOGSTASH_HOST:-localhost}</remoteHost>
-        <port>${LOGSTASH_PORT:-9001}</port>
-
-        <!-- encoder is required -->
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-    </appender>
-
-    <root level="INFO">
-        <appender-ref ref="logstash" />
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
     </root>
+
 </configuration>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,6 @@ object Dependencies {
 
   val logback         = "ch.qos.logback"              % "logback-classic"                      % Version.logback
   val scalaLogging    = "com.typesafe.scala-logging" %% "scala-logging"                        % Version.scalaLogging
-  val logstashLogback = "net.logstash.logback"        % "logstash-logback-encoder"             % Version.logstashLogback
 
   val scalaTest       = "org.scalatest"              %% "scalatest"                            % Version.scalaTest   % "it, test"
   val scalaCheck      = "org.scalacheck"             %% "scalacheck"                           % Version.scalaCheck  % "it, test"

--- a/project/GrasshopperBuild.scala
+++ b/project/GrasshopperBuild.scala
@@ -31,7 +31,7 @@ object GrasshopperBuild extends Build {
   import Dependencies._
   import BuildSettings._
 
-  val commonDeps = Seq(logback, scalaLogging, logstashLogback, scalaTest, scalaCheck)
+  val commonDeps = Seq(logback, scalaLogging, scalaTest, scalaCheck)
 
   val akkaDeps = commonDeps ++ Seq(akkaActor, akkaStreams)
 

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -2,7 +2,6 @@ object Version {
 
   val logback         = "1.1.2"
   val scalaLogging    = "3.1.0"
-  val logstashLogback = "4.2"
   val akka            = "2.3.9"
   val akkaStreams     = "1.0-RC2"
   val scalaTest       = "2.2.1"


### PR DESCRIPTION
Closes #101.

Here's the first pass at a setting up a distributed logging system for grasshopper.  It uses the _Official_ Official [Elasticsearch](https://registry.hub.docker.com/_/elasticsearch/) (existing) and [Logstash](https://registry.hub.docker.com/_/logstash/) images, semi-Official [gliderlabs/logspout](https://registry.hub.docker.com/u/gliderlabs/logspout/) image (gliderlabs wrote logspout), and [marcbachmann/kibana4](https://registry.hub.docker.com/u/marcbachmann/kibana4/) image (most feature-rich and :star:'d  Kibana image).

To fire it up, you just need to do a:

```
docker-compose up
```

To view logstash output:

```
curl http://{{boot2docker-ip}}:8000/logs/
```

To check out Kibana, browse to:

```
http://{{boot2docker-ip}}:5601/
```
