### PR TITLE
Batch Geocode

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,18 @@ $ sbt
 > test
 ```
 
-This will run unit and integration tests. The integration tests will stand up a temporary Elasticsearch node, no additional dependencies are needed.  
+This will run unit and integration tests. The integration tests will stand up a temporary Elasticsearch node, no additional dependencies are needed.
+
+In addition to regular testing, some projects (i.e. client, geocoder) also have integration tests that can be run against a live system.
+To run these, first make sure that the underlying dependencies have been deployed and are running (addresspoints, parser and census services).
+The underlying services need to have the necessary data to pass the tests.
+
+```
+$ sbt
+> project geocoder
+> it:test
+```
+
 
 ## Known issues
 

--- a/addresspoints/src/main/scala/grasshopper/addresspoints/AddressPointService.scala
+++ b/addresspoints/src/main/scala/grasshopper/addresspoints/AddressPointService.scala
@@ -4,7 +4,7 @@ import grasshopper.addresspoints.api.Service
 import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.Http
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import grasshopper.addresspoints.metrics.JvmMetrics
 import org.elasticsearch.client.transport.TransportClient
@@ -15,7 +15,7 @@ import scala.util.Properties
 object AddressPointService extends App with Service {
   override implicit val system = ActorSystem("grasshopper-addresspoints")
   override implicit val executor = system.dispatcher
-  override implicit val materializer = ActorFlowMaterializer()
+  override implicit val materializer = ActorMaterializer()
 
   override val config = ConfigFactory.load()
   override val logger = Logging(system, getClass)

--- a/addresspoints/src/main/scala/grasshopper/addresspoints/api/Service.scala
+++ b/addresspoints/src/main/scala/grasshopper/addresspoints/api/Service.scala
@@ -2,10 +2,7 @@ package grasshopper.addresspoints.api
 
 import java.net.InetAddress
 import java.time.Instant
-import feature.Feature
-import grasshopper.addresspoints.model.{ AddressPointsResult, AddressInput, Status }
-import grasshopper.addresspoints.protocol.AddressPointJsonProtocol
-import grasshopper.addresspoints.search.Geocode
+
 import akka.actor.ActorSystem
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.coding.{ Deflate, Gzip, NoCoding }
@@ -14,13 +11,17 @@ import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.StandardRoute
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.Logger
-import io.geojson.FeatureJsonProtocol._
+import feature.Feature
+import grasshopper.addresspoints.model.{ AddressInput, AddressPointsResult, Status }
+import grasshopper.addresspoints.protocol.AddressPointJsonProtocol
+import grasshopper.addresspoints.search.Geocode
 import org.elasticsearch.client.Client
 import org.slf4j.LoggerFactory
 import spray.json._
+
 import scala.concurrent.ExecutionContextExecutor
 
 trait Service extends AddressPointJsonProtocol with Geocode {
@@ -28,7 +29,7 @@ trait Service extends AddressPointJsonProtocol with Geocode {
 
   implicit def executor: ExecutionContextExecutor
 
-  implicit val materializer: ActorFlowMaterializer
+  implicit val materializer: ActorMaterializer
   implicit val client: Client
 
   def config: Config

--- a/census/src/main/scala/grasshopper/census/CensusGeocodeService.scala
+++ b/census/src/main/scala/grasshopper/census/CensusGeocodeService.scala
@@ -3,7 +3,7 @@ package grasshopper.census
 import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.Http
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import grasshopper.census.metrics.JvmMetrics
 import org.elasticsearch.client.transport.TransportClient
@@ -16,7 +16,7 @@ object CensusGeocodeService extends App with Service {
   override implicit val system: ActorSystem = ActorSystem("grasshopper-census")
 
   override implicit val executor = system.dispatcher
-  override implicit val materializer = ActorFlowMaterializer()
+  override implicit val materializer = ActorMaterializer()
 
   override val config = ConfigFactory.load()
   override val logger = Logging(system, getClass)

--- a/census/src/main/scala/grasshopper/census/api/Service.scala
+++ b/census/src/main/scala/grasshopper/census/api/Service.scala
@@ -2,34 +2,35 @@ package grasshopper.census.api
 
 import java.net.InetAddress
 import java.time.Instant
+
 import akka.actor.ActorSystem
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.coding.{ Deflate, Gzip, NoCoding }
-import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.StandardRoute
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.Logger
 import feature.Feature
-import org.elasticsearch.client.Client
-import org.slf4j.LoggerFactory
 import grasshopper.census.model.{ CensusResult, ParsedInputAddress, Status }
 import grasshopper.census.protocol.CensusJsonProtocol
-import spray.json._
-import io.geojson.FeatureJsonProtocol._
 import grasshopper.census.search.CensusGeocode
+import org.elasticsearch.client.Client
+import org.slf4j.LoggerFactory
+import spray.json._
+
 import scala.concurrent.ExecutionContextExecutor
-import scala.util.{ Success, Failure, Try }
+import scala.util.{ Failure, Success, Try }
 
 trait Service extends CensusJsonProtocol with CensusGeocode {
   implicit val system: ActorSystem
 
   implicit def executor: ExecutionContextExecutor
 
-  implicit val materializer: ActorFlowMaterializer
+  implicit val materializer: ActorMaterializer
   implicit val client: Client
 
   def config: Config

--- a/client/src/it/scala/grasshopper/client/addresspoints/AddressPointsClientSpec.scala
+++ b/client/src/it/scala/grasshopper/client/addresspoints/AddressPointsClientSpec.scala
@@ -19,7 +19,7 @@ class AddressPointsClientSpec extends FlatSpec with MustMatchers {
 
 
   "A request to /geocode" must "geocode an address string" in {
-    val maybeAddress = Await.result(AddressPointsClient.geocode("108+S+Main+St+Bentonville+AR+72712"), 1.seconds)
+    val maybeAddress = Await.result(AddressPointsClient.geocode("108 S Main St Bentonville AR 72712"), 1.seconds)
     maybeAddress match {
       case Right(result) =>
         result.status mustBe "OK"

--- a/client/src/it/scala/grasshopper/client/census/CensusClientSpec.scala
+++ b/client/src/it/scala/grasshopper/client/census/CensusClientSpec.scala
@@ -19,7 +19,7 @@ class CensusClientSpec extends FlatSpec with MustMatchers {
 
 
   "A request to /geocode" must "geocode an address string" in {
-    val parsedAddress = ParsedInputAddress(1311, "30th+St+NW", 20007, "DC")
+    val parsedAddress = ParsedInputAddress(3146, "M St NW", 20007, "DC")
     val maybeAddress = Await.result(CensusClient.geocode(parsedAddress), 10.seconds)
     maybeAddress match {
       case Right(result) =>
@@ -28,7 +28,7 @@ class CensusClientSpec extends FlatSpec with MustMatchers {
         features.size mustBe 1
         val f = features(0)
         val address = f.values.getOrElse("FULLNAME", "")
-        address mustBe "30th St NW"
+        address mustBe "M St NW"
       case Left(b) =>
         b.desc mustBe "503 Service Unavailable"
         fail("SERVICE_UNAVAILABLE")

--- a/client/src/it/scala/grasshopper/client/parser/AddressParserClientSpec.scala
+++ b/client/src/it/scala/grasshopper/client/parser/AddressParserClientSpec.scala
@@ -13,11 +13,12 @@ class AddressParserClientSpec extends FlatSpec with MustMatchers {
         s.status mustBe "OK"
       case Left(b) =>
         b.desc mustBe "503 Service Unavailable"
+        fail("SERVICE_UNAVAILABLE")
     }
   }
 
   "A request to /standardize" must "parse an address string" in {
-    val maybeAddress = Await.result(AddressParserClient.standardize("1311+30th+St+NW+washington+dc+20007"), 2.seconds)
+    val maybeAddress = Await.result(AddressParserClient.standardize("1311 30th St NW washington dc 20007"), 2.seconds)
     maybeAddress match {
       case Right(a) =>
         a.parts.addressNumber mustBe "1311"
@@ -27,6 +28,7 @@ class AddressParserClientSpec extends FlatSpec with MustMatchers {
         a.parts.zip mustBe "20007"
       case Left(b) =>
         b.desc mustBe "503 Service Unavailable"
+        fail("SERVICE_UNAVAILABLE")
     }
   }
 }

--- a/client/src/main/scala/grasshopper/client/ServiceClient.scala
+++ b/client/src/main/scala/grasshopper/client/ServiceClient.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model._
 import akka.stream.scaladsl.{ Sink, Source }
-import akka.stream.{ ActorFlowMaterializer, StreamTcpException }
+import akka.stream.{ ActorMaterializer, StreamTcpException }
 import akka.util.Timeout
 import com.typesafe.config.Config
 import grasshopper.client.model.ResponseError
@@ -17,7 +17,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 trait ServiceClient extends ClientJsonProtocol {
   implicit val askTimeout: Timeout = 1000.millis
   implicit val system: ActorSystem = ActorSystem("grasshopper-client")
-  implicit val materializer: ActorFlowMaterializer = ActorFlowMaterializer()
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   def host: String
   def port: String

--- a/client/src/main/scala/grasshopper/client/addresspoints/AddressPointsClient.scala
+++ b/client/src/main/scala/grasshopper/client/addresspoints/AddressPointsClient.scala
@@ -8,9 +8,9 @@ import grasshopper.client.ServiceClient
 import grasshopper.client.addresspoints.model.{ AddressPointsResult, AddressPointsStatus }
 import grasshopper.client.addresspoints.protocol.AddressPointsJsonProtocol
 import grasshopper.client.model.ResponseError
-
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Properties
+import java.net.URLEncoder
 
 object AddressPointsClient extends ServiceClient with AddressPointsJsonProtocol {
   override val config = ConfigFactory.load()
@@ -30,7 +30,9 @@ object AddressPointsClient extends ServiceClient with AddressPointsJsonProtocol 
 
   def geocode(address: String): Future[Either[ResponseError, AddressPointsResult]] = {
     implicit val ec: ExecutionContext = system.dispatcher
-    sendGetRequest(s"/addresses/points/${address}").flatMap { response =>
+    val addr = if (address.contains("?suggest=")) address else URLEncoder.encode(address, "UTF-8")
+    val url = s"/addresses/points/${addr}"
+    sendGetRequest(url).flatMap { response =>
       response.status match {
         case OK => Unmarshal(response.entity).to[AddressPointsResult].map(Right(_))
         case _ => sendResponseError(response)

--- a/client/src/main/scala/grasshopper/client/census/CensusClient.scala
+++ b/client/src/main/scala/grasshopper/client/census/CensusClient.scala
@@ -8,9 +8,9 @@ import grasshopper.client.ServiceClient
 import grasshopper.client.census.model.{ CensusResult, CensusStatus, ParsedInputAddress }
 import grasshopper.client.census.protocol.CensusJsonProtocol
 import grasshopper.client.model.ResponseError
-
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Properties
+import java.net.URLEncoder
 
 object CensusClient extends ServiceClient with CensusJsonProtocol {
   override val config: Config = ConfigFactory.load()
@@ -30,7 +30,8 @@ object CensusClient extends ServiceClient with CensusJsonProtocol {
 
   def geocode(address: ParsedInputAddress): Future[Either[ResponseError, CensusResult]] = {
     implicit val ec: ExecutionContext = system.dispatcher
-    val url = s"/census/addrfeat?number=${address.number}&streetName=${address.streetName}&zipCode=${address.zipCode}&state=${address.state}"
+    val streetName = URLEncoder.encode(address.streetName, "UTF-8")
+    val url = s"/census/addrfeat?number=${address.number}&streetName=${streetName}&zipCode=${address.zipCode}&state=${address.state}"
     sendGetRequest(url).flatMap { response =>
       response.status match {
         case OK => Unmarshal(response.entity).to[CensusResult].map(Right(_))

--- a/client/src/main/scala/grasshopper/client/parser/AddressParserClient.scala
+++ b/client/src/main/scala/grasshopper/client/parser/AddressParserClient.scala
@@ -10,6 +10,7 @@ import grasshopper.client.parser.model.{ ParserStatus, ParsedAddress }
 import grasshopper.client.parser.protocol.ParserJsonProtocol
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Properties
+import java.net.URLEncoder
 
 object AddressParserClient extends ServiceClient with ParserJsonProtocol {
   override val config = ConfigFactory.load()
@@ -29,7 +30,8 @@ object AddressParserClient extends ServiceClient with ParserJsonProtocol {
 
   def standardize(address: String): Future[Either[ResponseError, ParsedAddress]] = {
     implicit val ec: ExecutionContext = system.dispatcher
-    sendGetRequest(s"/standardize?address=${address}").flatMap { response =>
+    val url = s"/standardize?address=${URLEncoder.encode(address, "UTF-8")}"
+    sendGetRequest(url).flatMap { response =>
       response.status match {
         case OK => Unmarshal(response.entity).to[ParsedAddress].map(Right(_))
         case _ => sendResponseError(response)

--- a/client/src/main/scala/grasshopper/client/parser/model/ParsedAddress.scala
+++ b/client/src/main/scala/grasshopper/client/parser/model/ParsedAddress.scala
@@ -5,8 +5,7 @@ case class AddressPart(
   city: String,
   state: String,
   streetName: String,
-  zip: String
-)
+  zip: String)
 case class ParsedAddress(input: String, parts: AddressPart)
 
 object ParsedAddress {

--- a/client/src/main/scala/grasshopper/client/parser/model/ParsedAddress.scala
+++ b/client/src/main/scala/grasshopper/client/parser/model/ParsedAddress.scala
@@ -5,7 +5,8 @@ case class AddressPart(
   city: String,
   state: String,
   streetName: String,
-  zip: String)
+  zip: String
+)
 case class ParsedAddress(input: String, parts: AddressPart)
 
 object ParsedAddress {

--- a/docs/geocoder_public_api_spec.md
+++ b/docs/geocoder_public_api_spec.md
@@ -111,3 +111,14 @@ Each service has a status code that provides metadata about the geocode request 
 
 
 **3. Batch Geocode**
+
+`POST /geocode`
+
+The request must send a file with one address string per line as `multipart/form-data`.
+This endpoint will geocode the addresses in parallel and choose the best option from the available geocoders.
+The response is a chunked response, and starts sending data to download as soon as the geocoding process begins.
+
+Eventually a file is saved to disk, with the following format:
+
+`input_address,latitude,longitude`
+

--- a/geocoder/src/it/scala/grasshopper/geocoder/api/GeocodeFlowsSpec.scala
+++ b/geocoder/src/it/scala/grasshopper/geocoder/api/GeocodeFlowsSpec.scala
@@ -1,0 +1,107 @@
+package grasshopper.geocoder.api
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Sink, Source}
+import grasshopper.client.census.model.ParsedInputAddress
+import grasshopper.client.parser.model.{AddressPart, ParsedAddress}
+import grasshopper.geocoder.model.ParsedOutputBatchAddress
+import org.scalatest.{FlatSpec, MustMatchers}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class GeocodeFlowsSpec extends FlatSpec with MustMatchers {
+
+  implicit val system = ActorSystem("sys")
+  implicit val mat = ActorMaterializer()
+  implicit val ec = system.dispatcher
+
+  "GeocodeFlows" must "parse a list of addresses" in {
+    val addresses =
+      List(
+        "1311 30th St NW Washington DC 20007",
+        "3146 M St NW Washington DC 20007",
+        "198 President St Arkansas City AR 71630",
+        "1 Main St City ST 00001"
+      ).toIterator
+
+    val source = Source(() => addresses)
+    val future = source.via(GeocodeFlows.parseFlow).grouped(4).runWith(Sink.head)
+    val result = Await.result(future, 2.seconds)
+    result.size mustBe 4
+    result.head.input mustBe "1311 30th St NW Washington DC 20007"
+    result.head.parts.addressNumber mustBe "1311"
+    result.head.parts.city mustBe "Washington"
+    result.head.parts.state mustBe "DC"
+    result.head.parts.zip mustBe "20007"
+
+    result.tail.head.input mustBe "3146 M St NW Washington DC 20007"
+    result.tail.head.parts.addressNumber mustBe "3146"
+    result.tail.head.parts.city mustBe "Washington"
+    result.tail.head.parts.state mustBe "DC"
+    result.tail.head.parts.zip mustBe "20007"
+  }
+
+  it must "transform parsed addresses into batch parsed addresses" in {
+    val inputParsedList = List(
+      ParsedAddress("1311 30th St NW Washington DC 20007",
+        AddressPart("1311","Washington","DC","30th St NW","20007")),
+      ParsedAddress("3146 M St NW Washington DC 20007",
+        AddressPart("3146","Washington","DC","M St NW","20007")),
+      ParsedAddress("198 President St Arkansas City AR 71630",
+        AddressPart("198","Arkansas City","AR","President St","71630")),
+      ParsedAddress("1 Main St City ST 00001",AddressPart("1","St City","ST","Main","00001")))
+
+    val source = Source(() => inputParsedList.toIterator)
+    val future = source.via(GeocodeFlows.parsedInputAddressFlow).grouped(4).runWith(Sink.head)
+    val result = Await.result(future, 2.seconds)
+    result.size mustBe 4
+    result.head.input mustBe "1311 30th St NW Washington DC 20007"
+    result.head.parsed mustBe ParsedInputAddress(1311, "30th St NW", 20007, "DC")
+
+    result.tail.head.input mustBe "3146 M St NW Washington DC 20007"
+    result.tail.head.parsed mustBe ParsedInputAddress(3146, "M St NW", 20007, "DC")
+  }
+
+  it must "geocode batch parsed addresses into TIGER line results" in {
+    val parsedBatchList =
+      List(
+        ParsedOutputBatchAddress("1311 30th St NW Washington DC 20007",
+          ParsedInputAddress(1311, "30th St NW", 20007, "DC")),
+        ParsedOutputBatchAddress("3146 M St NW Washington DC 20007",
+          ParsedInputAddress(3146, "M St NW",20007, "DC")),
+        ParsedOutputBatchAddress("198 President St Arkansas City AR 71630",
+          ParsedInputAddress(198, "President St", 71630, "AR")),
+        ParsedOutputBatchAddress("1 Main St City ST 00001",
+          ParsedInputAddress(1, "Main ST", 1,"ST")))
+
+    val source = Source(() => parsedBatchList.toIterator)
+    val future = source.via(GeocodeFlows.censusFlow).grouped(4).runWith(Sink.head)
+    val result = Await.result(future, 2.seconds)
+    result.size mustBe 4
+    result.head.input mustBe "1311 30th St NW Washington DC 20007"
+    result.head.latitude mustBe 38.907211343944184
+    result.head.longitude mustBe -77.05928851011977
+  }
+
+  it must "geocode addresses into points" in {
+    val addresses =
+      List(
+        "1311 30th St NW Washington DC 20007",
+        "3146 M St NW Washington DC 20007",
+        "198 President St Arkansas City AR 71630",
+        "1 Main St City ST 00001"
+      ).toIterator
+
+    val source = Source(() => addresses)
+    val future = source.via(GeocodeFlows.addressPointsFlow).grouped(4).runWith(Sink.head)
+    val result = Await.result(future, 2.seconds)
+    println(result)
+    result.size mustBe 4
+    result.tail.tail.head.input mustBe "198 President St Arkansas City AR 71630"
+    result.tail.tail.head.latitude mustBe 33.60824683723317
+    result.tail.tail.head.longitude mustBe -91.19986550300061
+
+  }
+}

--- a/geocoder/src/main/scala/grasshopper/GrasshopperGeocoder.scala
+++ b/geocoder/src/main/scala/grasshopper/GrasshopperGeocoder.scala
@@ -3,7 +3,7 @@ package grasshopper.geocoder
 import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.Http
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import grasshopper.geocoder.metrics.JvmMetrics
 import grasshopper.geocoder.api.Service
@@ -14,7 +14,7 @@ object GrasshopperGeocoder extends App with Service {
   override implicit val system: ActorSystem = ActorSystem("grasshopper-geocoder")
 
   override implicit val executor = system.dispatcher
-  override implicit val materializer = ActorFlowMaterializer()
+  override implicit val materializer = ActorMaterializer()
 
   override val config = ConfigFactory.load()
   override val logger = Logging(system, getClass)

--- a/geocoder/src/main/scala/grasshopper/geocoder/api/GeocodeFlow.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/api/GeocodeFlow.scala
@@ -1,0 +1,123 @@
+package grasshopper.geocoder.api
+
+import akka.stream.scaladsl._
+import grasshopper.client.addresspoints.AddressPointsClient
+import grasshopper.client.addresspoints.model.AddressPointsResult
+import grasshopper.client.census.CensusClient
+import grasshopper.client.census.model.{ CensusResult, ParsedInputAddress }
+import grasshopper.client.parser.AddressParserClient
+import grasshopper.client.parser.model.ParsedAddress
+import grasshopper.geocoder.model.{ BatchGeocodeResult, AddressPointsGeocodeBatchResult, CensusGeocodeBatchResult, ParsedOutputBatchAddress }
+
+import scala.concurrent.ExecutionContext
+
+object GeocodeFlows {
+
+  def parseFlow: Flow[String, ParsedAddress, Unit] = {
+    Flow[String]
+      .mapAsync(4)(a => AddressParserClient.standardize(a))
+      .map { x =>
+        if (x.isRight) {
+          x.right.getOrElse(ParsedAddress.empty)
+        } else {
+          ParsedAddress.empty
+        }
+      }
+  }
+
+  def parsedInputAddressFlow: Flow[ParsedAddress, ParsedOutputBatchAddress, Unit] = {
+    Flow[ParsedAddress]
+      .map(a =>
+        ParsedOutputBatchAddress(
+          a.input,
+          ParsedInputAddress(
+            a.parts.addressNumber.toInt,
+            a.parts.streetName,
+            a.parts.zip.toInt,
+            a.parts.state
+          )
+        ))
+  }
+
+  def censusFlow(implicit ec: ExecutionContext): Flow[ParsedOutputBatchAddress, CensusGeocodeBatchResult, Unit] = {
+    Flow[ParsedOutputBatchAddress]
+      .mapAsync(4) { p =>
+        CensusClient.geocode(p.parsed).map { x =>
+          if (x.isRight) {
+            val result = x.right.getOrElse(CensusResult.empty)
+            val longitude = if (!result.features.isEmpty) {
+              result.features.toList.head.geometry.centroid.x
+            } else {
+              0
+            }
+            val latitude = if (!result.features.isEmpty) {
+              result.features.toList.head.geometry.centroid.y
+            } else {
+              0
+            }
+            CensusGeocodeBatchResult(p.input, latitude, longitude)
+          } else {
+            val result = CensusResult.error
+            CensusGeocodeBatchResult(p.input, 0.0, 0.0)
+          }
+        }
+      }
+  }
+
+  def addressPointsFlow(implicit ec: ExecutionContext): Flow[String, AddressPointsGeocodeBatchResult, Unit] = {
+    Flow[String]
+      .mapAsync(4) { a =>
+        AddressPointsClient.geocode(a).map { x =>
+          if (x.isRight) {
+            val result = x.right.getOrElse(AddressPointsResult.empty)
+            val longitude = if (!result.features.isEmpty) {
+              result.features.toList.head.geometry.centroid.x
+            } else {
+              0
+            }
+            val latitude = if (!result.features.isEmpty) {
+              result.features.toList.head.geometry.centroid.y
+            } else {
+              0
+            }
+            AddressPointsGeocodeBatchResult(a, latitude, longitude)
+          } else {
+            AddressPointsGeocodeBatchResult(a, 0.0, 0.0)
+          }
+        }
+      }
+  }
+
+  def chooseGeocode: Flow[(CensusGeocodeBatchResult, AddressPointsGeocodeBatchResult), BatchGeocodeResult, Unit] = {
+    Flow[(CensusGeocodeBatchResult, AddressPointsGeocodeBatchResult)].map {
+      case (b1, b2) =>
+        if (b2.latitude != 0 && b2.longitude != 0) {
+          b2
+        } else {
+          b1
+        }
+    }
+  }
+
+  def geocode(implicit ec: ExecutionContext): Flow[String, BatchGeocodeResult, Unit] = {
+    Flow() { implicit b =>
+      import FlowGraph.Implicits._
+
+      val input = b.add(Flow[String])
+      val broadcast = b.add(Broadcast[String](2))
+      val parse = b.add(parseFlow)
+      val parseInput = b.add(parsedInputAddressFlow)
+      val census = b.add(censusFlow)
+      val addressPoints = b.add(addressPointsFlow)
+      val zip = b.add(Zip[CensusGeocodeBatchResult, AddressPointsGeocodeBatchResult]())
+      val choose = b.add(chooseGeocode)
+
+      input ~> broadcast ~> parse ~> parseInput ~> census ~> zip.in0
+      broadcast ~> addressPoints ~> zip.in1
+      zip.out ~> choose
+
+      (input.inlet, choose.outlet)
+    }
+  }
+}
+

--- a/geocoder/src/main/scala/grasshopper/geocoder/api/Service.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/api/Service.scala
@@ -8,6 +8,7 @@ import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model.Multipart.FormData
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Source
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.Logger
 import grasshopper.client.addresspoints.AddressPointsClient
@@ -55,11 +56,38 @@ trait Service extends GrasshopperJsonProtocol with ClientJsonProtocol {
     } ~
       path("geocode") {
         post {
+          //          extractRequest { request =>
+          //            request.entity.dataBytes
+          //              .via(
+          //                Framing.delimiter(ByteString("\r\n"), maximumFrameLength = 1000, allowTruncation = true)
+          //              ).map(_.utf8String)
+          //              .to(Sink.foreach(println)).run()
+          //            complete("uploaded")
+          //          }
           entity(as[FormData]) { formData =>
-            complete {
-              "OK BATCH"
+            val list = formData.parts.map { bodyPart =>
+              bodyPart.entity.dataBytes.map { byteString =>
+                Source(List(byteString)).map { e =>
+                  e.utf8String
+                  //Files.write(tempFile, e.toArray, StandardOpenOption.APPEND)
+                }
+              }
             }
+            complete { "OK" }
           }
+          //          entity(as[FormData]) { formData =>
+          //            val parts = formData.parts
+          //            parts.runForeach { bodyPart =>
+          //              bodyPart.entity.dataBytes.runForeach { byteString =>
+          //                Source(List(byteString)).runForeach { e =>
+          //                  println(e.toArray)
+          //                }
+          //              }
+          //            }
+          //            complete {
+          //              "OK BATCH"
+          //            }
+          //          }
         }
       } ~
       path("geocode" / Segment) { address =>

--- a/geocoder/src/main/scala/grasshopper/geocoder/api/Service.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/api/Service.scala
@@ -5,27 +5,24 @@ import akka.event.LoggingAdapter
 import akka.http.scaladsl.coding.{ Deflate, Gzip, NoCoding }
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
+import akka.http.scaladsl.model.Multipart.FormData
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorFlowMaterializer
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.Logger
-import feature.Feature
-import grasshopper.client.protocol.ClientJsonProtocol
-import io.geojson.FeatureJsonProtocol._
 import grasshopper.client.addresspoints.AddressPointsClient
 import grasshopper.client.addresspoints.model.{ AddressPointsResult, AddressPointsStatus }
 import grasshopper.client.census.CensusClient
 import grasshopper.client.census.model.{ CensusResult, CensusStatus, ParsedInputAddress }
-import grasshopper.client.model.ResponseError
 import grasshopper.client.parser.AddressParserClient
 import grasshopper.client.parser.model.{ ParsedAddress, ParserStatus }
+import grasshopper.client.protocol.ClientJsonProtocol
 import grasshopper.geocoder.model.{ GeocodeResult, GeocodeStatus }
 import grasshopper.geocoder.protocol.GrasshopperJsonProtocol
-import io.geojson.FeatureJsonProtocol._
 import org.slf4j.LoggerFactory
+
 import scala.async.Async.{ async, await }
 import scala.concurrent.{ ExecutionContextExecutor, Future }
-import spray.json._
 
 trait Service extends GrasshopperJsonProtocol with ClientJsonProtocol {
   implicit val system: ActorSystem
@@ -56,8 +53,16 @@ trait Service extends GrasshopperJsonProtocol with ClientJsonProtocol {
         }
       }
     } ~
+      path("geocode") {
+        post {
+          entity(as[FormData]) { formData =>
+            complete {
+              "OK BATCH"
+            }
+          }
+        }
+      } ~
       path("geocode" / Segment) { address =>
-
         val fParsed: Future[(ParsedAddress, ParsedInputAddress)] = async {
           val addr = await(AddressParserClient.standardize(address))
           if (addr.isLeft) {

--- a/geocoder/src/main/scala/grasshopper/geocoder/api/Service.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/api/Service.scala
@@ -63,7 +63,6 @@ trait Service extends GrasshopperJsonProtocol with ClientJsonProtocol {
           entity(as[FormData]) { formData =>
             complete {
               val source = formData.parts
-                .log("", p => p.filename)
                 .mapAsync(4) { bodyPart =>
                   bodyPart.entity.dataBytes.runFold(ByteString.empty)(_ ++ _).map { contents =>
                     contents

--- a/geocoder/src/main/scala/grasshopper/geocoder/api/Service.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/api/Service.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model.Multipart.FormData
 import akka.http.scaladsl.server.Directives._
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.Logger
 import grasshopper.client.addresspoints.AddressPointsClient
@@ -28,7 +28,7 @@ trait Service extends GrasshopperJsonProtocol with ClientJsonProtocol {
   implicit val system: ActorSystem
 
   implicit def executor: ExecutionContextExecutor
-  implicit val materializer: ActorFlowMaterializer
+  implicit val materializer: ActorMaterializer
 
   def config: Config
 

--- a/geocoder/src/main/scala/grasshopper/geocoder/batch/TestBatch.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/batch/TestBatch.scala
@@ -34,7 +34,8 @@ object TestBatch extends App {
 
   val addresses2 = List(
     ByteString("1311 30th St NW Washington DC 20007\r\n"),
-    ByteString("3146 M St NW Washington DC 20007\r\n")).toIterator
+    ByteString("3146 M St NW Washington DC 20007\r\n")
+  ).toIterator
 
   val source = Source(() => addresses2)
 
@@ -42,7 +43,9 @@ object TestBatch extends App {
     Framing.delimiter(
       ByteString("\r\n"),
       maximumFrameLength = 100,
-      allowTruncation = true))
+      allowTruncation = true
+    )
+  )
     .map(_.utf8String)
 
   //linesStream.to(Sink.foreach { x => println(x) }).run()

--- a/geocoder/src/main/scala/grasshopper/geocoder/batch/TestBatch.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/batch/TestBatch.scala
@@ -2,14 +2,16 @@ package grasshopper.geocoder.batch
 
 import akka.actor.ActorSystem
 import akka.stream.Supervision.Decider
-import akka.stream.scaladsl.{Flow, Sink, Source}
-import akka.stream.{ActorFlowMaterializer, ActorFlowMaterializerSettings, Supervision}
+import akka.stream.scaladsl.{ Flow, Sink, Source, FlowGraph }
+import akka.stream.{ ActorFlowMaterializer, ActorFlowMaterializerSettings, Supervision }
 import grasshopper.client.addresspoints.AddressPointsClient
 import grasshopper.client.census.model.ParsedInputAddress
 import grasshopper.client.parser.AddressParserClient
 import grasshopper.client.parser.model.ParsedAddress
-
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
+import akka.stream.impl.Broadcast
+import akka.stream.scaladsl.Merge
+import akka.stream.scaladsl.Broadcast
 
 object TestBatch extends App {
 
@@ -22,45 +24,75 @@ object TestBatch extends App {
   implicit val actorSystem = ActorSystem("sys")
   implicit val mat = ActorFlowMaterializer(
     ActorFlowMaterializerSettings(actorSystem)
-      .withSupervisionStrategy(decider)
-  )
+      .withSupervisionStrategy(decider))
   implicit val ec: ExecutionContext = actorSystem.dispatcher
-
 
   val addresses =
     List(
       ParsedInputAddress(1311, "30th St", 20007, "DC"),
       ParsedInputAddress(2100, "31th St", 20007, "DC"),
-      ParsedInputAddress.empty
-    ).toIterator
+      ParsedInputAddress.empty).toIterator
 
   def futureAddress(address: ParsedInputAddress): Future[ParsedInputAddress] = {
     Future(address)
   }
 
-  val source: Source[ParsedInputAddress,  Unit] = Source(() => addresses)
+  val source: Source[ParsedInputAddress, Unit] = Source(() => addresses)
 
   val parseFlow = {
     Flow[ParsedInputAddress]
       .mapAsync(2)(a => AddressParserClient.standardize(a.toString().replace(" ", "+")))
       .map { x =>
-      if (x.isRight) {
-        x.right.getOrElse(ParsedAddress.empty).input.toString
-      } else if (x.isLeft) {
-        "Address cannot be parsed"
+        if (x.isRight) {
+          x.right.getOrElse(ParsedAddress.empty).input.toString
+        } else if (x.isLeft) {
+          "Address cannot be parsed"
+        }
       }
-    }
   }
 
   val geocodeFlow = {
     Flow[String]
-      .mapAsync(2)(s => AddressPointsClient.geocode(s))
+      .mapAsync(2)(s => AddressPointsClient.geocode(s.replace(" ", "+")))
       .map { x =>
         if (x.isRight) x.right.get.features.head
       }
   }
 
+  //  def graphFlow = {
+  //    Flow() { implicit builder: FlowGraph.Builder[Unit] =>
+  //      import FlowGraph.Implicits._
+  //      val in = Source(1 to 10)
+  //      val out = Sink.ignore
+  //
+  //      val bcast = builder.add(Broadcast[Int](2))
+  //      val merge = builder.add(Merge[Int](2))
+  //
+  //      val f1, f2, f3, f4 = Flow[Int].map(_ + 10)
+  //
+  //      in ~> f1 ~> bcast ~> f2 ~> merge ~> f3 ~> out
+  //      bcast ~> f4 ~> merge
+  //
+  //    }
+  //  }
+
+  // def graphFlow = {
+  //   Flow() { implicit b =>
+  //     import FlowGraph.Implicits._
+
+  //     val out = Sink.ignore
+
+  //     val parse = b.add(parseFlow)
+  //     val geocode = b.add(geocodeFlow)
+
+  //     source ~> parse ~> out
+
+  //   }
+  // }
+
   val sink = Sink.foreach(println)
+
+  source.via(parseFlow).to(sink).run()
 
   //  source
   //    .via(parseFlow)
@@ -72,9 +104,9 @@ object TestBatch extends App {
 
   // source ~> parseFlow ~> geocodeFlow ~> sink
 
-//  val g = FlowGraph {
-//
-//  }
+  //  val g = FlowGraph {
+  //
+  //  }
 
   //source.runWith(sink)
 

--- a/geocoder/src/main/scala/grasshopper/geocoder/batch/TestBatch.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/batch/TestBatch.scala
@@ -1,0 +1,81 @@
+package grasshopper.geocoder.batch
+
+import akka.actor.ActorSystem
+import akka.stream.Supervision.Decider
+import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.stream.{ActorFlowMaterializer, ActorFlowMaterializerSettings, Supervision}
+import grasshopper.client.addresspoints.AddressPointsClient
+import grasshopper.client.census.model.ParsedInputAddress
+import grasshopper.client.parser.AddressParserClient
+import grasshopper.client.parser.model.ParsedAddress
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object TestBatch extends App {
+
+  // Stream supervision, what to do when an element fails
+  val decider: Decider = exc => exc match {
+    case _: ArithmeticException => Supervision.Stop
+    case _ => Supervision.Resume
+  }
+
+  implicit val actorSystem = ActorSystem("sys")
+  implicit val mat = ActorFlowMaterializer(
+    ActorFlowMaterializerSettings(actorSystem)
+      .withSupervisionStrategy(decider)
+  )
+  implicit val ec: ExecutionContext = actorSystem.dispatcher
+
+
+  val addresses =
+    List(
+      ParsedInputAddress(1311, "30th St", 20007, "DC"),
+      ParsedInputAddress(2100, "31th St", 20007, "DC"),
+      ParsedInputAddress.empty
+    ).toIterator
+
+  def futureAddress(address: ParsedInputAddress): Future[ParsedInputAddress] = {
+    Future(address)
+  }
+
+  val source: Source[ParsedInputAddress,  Unit] = Source(() => addresses)
+
+  val parseFlow = {
+    Flow[ParsedInputAddress]
+      .mapAsync(2)(a => AddressParserClient.standardize(a.toString().replace(" ", "+")))
+      .map { x =>
+      if (x.isRight) {
+        x.right.getOrElse(ParsedAddress.empty).input.toString
+      } else if (x.isLeft) {
+        "Address cannot be parsed"
+      }
+    }
+  }
+
+  val geocodeFlow = {
+    Flow[String]
+      .mapAsync(2)(s => AddressPointsClient.geocode(s))
+      .map { x =>
+        if (x.isRight) x.right.get.features.head
+      }
+  }
+
+  val sink = Sink.foreach(println)
+
+  //  source
+  //    .via(parseFlow)
+  //    .grouped(10000)
+  //    .runWith(Sink.head)
+  //    .map(e => println(e))
+
+  //source.via(parseFlow).via(geocodeFlow).to(sink).run()
+
+  // source ~> parseFlow ~> geocodeFlow ~> sink
+
+//  val g = FlowGraph {
+//
+//  }
+
+  //source.runWith(sink)
+
+}

--- a/geocoder/src/main/scala/grasshopper/geocoder/batch/TestBatch.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/batch/TestBatch.scala
@@ -4,19 +4,9 @@ import akka.actor.ActorSystem
 import akka.stream.Supervision.Decider
 import akka.stream.scaladsl._
 import akka.stream.{ ActorFlowMaterializer, ActorFlowMaterializerSettings, Supervision }
-import grasshopper.client.addresspoints.AddressPointsClient
-import grasshopper.client.addresspoints.model.AddressPointsResult
-import grasshopper.client.census.CensusClient
-import grasshopper.client.census.model.{ CensusResult, ParsedInputAddress }
-import grasshopper.client.parser.AddressParserClient
-import grasshopper.client.parser.model.ParsedAddress
+import grasshopper.geocoder.api.GeocodeFlows
 
 import scala.concurrent.ExecutionContext
-
-case class ParsedOutputAddress(input: String, parsed: ParsedInputAddress)
-case class BatchInputParsedAddress(input: String, parsedInputAddress: ParsedInputAddress)
-case class CensusBatchGeocodeResult(input: String, latitude: Double, longitude: Double)
-case class AddressPointsBatchGeocodeResult(input: String, latitude: Double, longitude: Double)
 
 object TestBatch extends App {
 
@@ -26,12 +16,12 @@ object TestBatch extends App {
     case _ => Supervision.Resume
   }
 
-  implicit val actorSystem = ActorSystem("sys")
+  implicit val system = ActorSystem("sys")
   implicit val mat = ActorFlowMaterializer(
-    ActorFlowMaterializerSettings(actorSystem)
+    ActorFlowMaterializerSettings(system)
       .withSupervisionStrategy(decider)
   )
-  implicit val ec: ExecutionContext = actorSystem.dispatcher
+  implicit val ec: ExecutionContext = system.dispatcher
 
   val addresses =
     List(
@@ -41,111 +31,10 @@ object TestBatch extends App {
       "1 Main St City ST 00001"
     ).toIterator
 
-  val source: Source[String, Unit] = Source(() => addresses)
+  val source2 = Source(() => addresses)
 
-  val parseFlow: Flow[String, ParsedAddress, Unit] = {
-    Flow[String]
-      .mapAsync(4)(a => AddressParserClient.standardize(a))
-      .map { x =>
-        if (x.isRight) {
-          x.right.getOrElse(ParsedAddress.empty)
-        } else {
-          ParsedAddress.empty
-        }
-      }
-  }
-
-  val parsedInputAddressFlow: Flow[ParsedAddress, ParsedOutputAddress, Unit] = {
-    Flow[ParsedAddress]
-      .map(a =>
-        ParsedOutputAddress(
-          a.input,
-          ParsedInputAddress(
-            a.parts.addressNumber.toInt,
-            a.parts.streetName,
-            a.parts.zip.toInt,
-            a.parts.state
-          )
-        ))
-  }
-
-  val censusFlow: Flow[ParsedOutputAddress, CensusBatchGeocodeResult, Unit] = {
-    Flow[ParsedOutputAddress]
-      .mapAsync(4) { p =>
-        CensusClient.geocode(p.parsed).map { x =>
-          if (x.isRight) {
-            val result = x.right.getOrElse(CensusResult.empty)
-            val longitude = if (!result.features.isEmpty) {
-              result.features.toList.head.geometry.centroid.x
-            } else {
-              0
-            }
-            val latitude = if (!result.features.isEmpty) {
-              result.features.toList.head.geometry.centroid.y
-            } else {
-              0
-            }
-            CensusBatchGeocodeResult(p.input, latitude, longitude)
-          } else {
-            val result = CensusResult.error
-            CensusBatchGeocodeResult(p.input, 0.0, 0.0)
-          }
-        }
-      }
-  }
-
-  val addressPointsFlow: Flow[String, AddressPointsBatchGeocodeResult, Unit] = {
-    Flow[String]
-      .mapAsync(4) { a =>
-        AddressPointsClient.geocode(a).map { x =>
-          if (x.isRight) {
-            val result = x.right.getOrElse(AddressPointsResult.empty)
-            val longitude = if (!result.features.isEmpty) {
-              result.features.toList.head.geometry.centroid.x
-            } else {
-              0
-            }
-            val latitude = if (!result.features.isEmpty) {
-              result.features.toList.head.geometry.centroid.y
-            } else {
-              0
-            }
-            AddressPointsBatchGeocodeResult(a, latitude, longitude)
-          } else {
-            AddressPointsBatchGeocodeResult(a, 0.0, 0.0)
-          }
-        }
-      }
-  }
-
-  val sink = Sink.foreach(println)
-
-  //  source
-  //    .via(parseFlow)
-  //    .via(parsedInputAddressFlow)
-  //    .via(censusFlow)
-  //    .to(sink).run()
-
-  val g = FlowGraph.closed() { implicit builder: FlowGraph.Builder[Unit] =>
-    import FlowGraph.Implicits._
-
-    val broadcast = builder.add(Broadcast[String](2))
-    val zip = builder.add(Zip[CensusBatchGeocodeResult, AddressPointsBatchGeocodeResult]())
-
-    source ~> broadcast ~> parseFlow ~> parsedInputAddressFlow ~> censusFlow ~> zip.in0
-    broadcast ~> addressPointsFlow ~> zip.in1
-    zip.out ~> Flow[(CensusBatchGeocodeResult, AddressPointsBatchGeocodeResult)].map {
-      case (b1, b2) =>
-        if (b2.latitude != 0 && b2.longitude != 0) {
-          b2
-        } else {
-          b1
-        }
-      //(b1, b2)
-    } ~> sink
-
-  }
-
-  g.run()
+  source2
+    .via(GeocodeFlows.geocode)
+    .to(Sink.foreach(println)).run()
 
 }

--- a/geocoder/src/main/scala/grasshopper/geocoder/batch/TestBatch.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/batch/TestBatch.scala
@@ -2,20 +2,25 @@ package grasshopper.geocoder.batch
 
 import akka.actor.ActorSystem
 import akka.stream.Supervision.Decider
-import akka.stream.scaladsl.{ Flow, Sink, Source, FlowGraph }
+import akka.stream.scaladsl._
 import akka.stream.{ ActorFlowMaterializer, ActorFlowMaterializerSettings, Supervision }
 import grasshopper.client.addresspoints.AddressPointsClient
-import grasshopper.client.census.model.ParsedInputAddress
+import grasshopper.client.addresspoints.model.AddressPointsResult
+import grasshopper.client.census.CensusClient
+import grasshopper.client.census.model.{ CensusResult, ParsedInputAddress }
 import grasshopper.client.parser.AddressParserClient
 import grasshopper.client.parser.model.ParsedAddress
-import scala.concurrent.{ ExecutionContext, Future }
-import akka.stream.impl.Broadcast
-import akka.stream.scaladsl.Merge
-import akka.stream.scaladsl.Broadcast
+
+import scala.concurrent.ExecutionContext
+
+case class BatchInputParsedAddress(input: String, parsedInputAddress: ParsedInputAddress)
+case class BatchGeocodeResult(service: String, input: String, latitude: Double, longitude: Double) {
+  //override def toString = s"${input},${latitude},${longitude}"
+}
 
 object TestBatch extends App {
 
-  // Stream supervision, what to do when an element fails
+  // Stream supervision, what to do with the stream when an element fails
   val decider: Decider = exc => exc match {
     case _: ArithmeticException => Supervision.Stop
     case _ => Supervision.Resume
@@ -24,90 +29,104 @@ object TestBatch extends App {
   implicit val actorSystem = ActorSystem("sys")
   implicit val mat = ActorFlowMaterializer(
     ActorFlowMaterializerSettings(actorSystem)
-      .withSupervisionStrategy(decider))
+      .withSupervisionStrategy(decider)
+  )
   implicit val ec: ExecutionContext = actorSystem.dispatcher
 
   val addresses =
     List(
-      ParsedInputAddress(1311, "30th St", 20007, "DC"),
-      ParsedInputAddress(2100, "31th St", 20007, "DC"),
-      ParsedInputAddress.empty).toIterator
+      "1311 30th St NW Washington DC 20007",
+      "3146 M St NW Washington DC 20007",
+      "198 President St Arkansas City AR 71630",
+      ""
+    ).toIterator
 
-  def futureAddress(address: ParsedInputAddress): Future[ParsedInputAddress] = {
-    Future(address)
-  }
+  val source: Source[String, Unit] = Source(() => addresses)
 
-  val source: Source[ParsedInputAddress, Unit] = Source(() => addresses)
-
-  val parseFlow = {
-    Flow[ParsedInputAddress]
-      .mapAsync(2)(a => AddressParserClient.standardize(a.toString().replace(" ", "+")))
+  val parseFlow: Flow[String, ParsedAddress, Unit] = {
+    Flow[String]
+      .mapAsync(4)(a => AddressParserClient.standardize(a))
       .map { x =>
         if (x.isRight) {
-          x.right.getOrElse(ParsedAddress.empty).input.toString
-        } else if (x.isLeft) {
-          "Address cannot be parsed"
+          x.right.getOrElse(ParsedAddress.empty)
+        } else {
+          ParsedAddress.empty
         }
       }
   }
 
-  val geocodeFlow = {
-    Flow[String]
-      .mapAsync(2)(s => AddressPointsClient.geocode(s.replace(" ", "+")))
-      .map { x =>
-        if (x.isRight) x.right.get.features.head
+  case class ParsedOutputAddress(input: String, parsed: ParsedInputAddress)
+
+  val parsedInputAddressFlow: Flow[ParsedAddress, ParsedOutputAddress, Unit] = {
+    Flow[ParsedAddress]
+      .map(a =>
+        ParsedOutputAddress(
+          a.input,
+          ParsedInputAddress(
+            a.parts.addressNumber.toInt,
+            a.parts.streetName,
+            a.parts.zip.toInt,
+            a.parts.state
+          )
+        ))
+  }
+
+  val censusFlow: Flow[ParsedOutputAddress, BatchGeocodeResult, Unit] = {
+    Flow[ParsedOutputAddress]
+      .mapAsync(4) { p =>
+        CensusClient.geocode(p.parsed).map { x =>
+          if (x.isRight) {
+            val result = x.right.getOrElse(CensusResult.empty)
+            val longitude = result.features.toList.head.geometry.centroid.x
+            val latitude = result.features.toList.head.geometry.centroid.y
+            BatchGeocodeResult("census", p.input, latitude, longitude)
+          } else {
+            val result = CensusResult.error
+            BatchGeocodeResult("census", p.input, 0.0, 0.0)
+          }
+        }
       }
   }
 
-  //  def graphFlow = {
-  //    Flow() { implicit builder: FlowGraph.Builder[Unit] =>
-  //      import FlowGraph.Implicits._
-  //      val in = Source(1 to 10)
-  //      val out = Sink.ignore
-  //
-  //      val bcast = builder.add(Broadcast[Int](2))
-  //      val merge = builder.add(Merge[Int](2))
-  //
-  //      val f1, f2, f3, f4 = Flow[Int].map(_ + 10)
-  //
-  //      in ~> f1 ~> bcast ~> f2 ~> merge ~> f3 ~> out
-  //      bcast ~> f4 ~> merge
-  //
-  //    }
-  //  }
-
-  // def graphFlow = {
-  //   Flow() { implicit b =>
-  //     import FlowGraph.Implicits._
-
-  //     val out = Sink.ignore
-
-  //     val parse = b.add(parseFlow)
-  //     val geocode = b.add(geocodeFlow)
-
-  //     source ~> parse ~> out
-
-  //   }
-  // }
+  val addressPointsFlow: Flow[String, BatchGeocodeResult, Unit] = {
+    Flow[String]
+      .mapAsync(4) { a =>
+        AddressPointsClient.geocode(a).map { x =>
+          if (x.isRight) {
+            val result = x.right.getOrElse(AddressPointsResult.empty)
+            val longitude = result.features.toList.head.geometry.centroid.x
+            val latitude = result.features.toList.head.geometry.centroid.y
+            BatchGeocodeResult("addresspoints", a, latitude, longitude)
+          } else {
+            val result = AddressPointsResult.error
+            BatchGeocodeResult("addresspoints", a, 0.0, 0.0)
+          }
+        }
+      }
+  }
 
   val sink = Sink.foreach(println)
 
-  source.via(parseFlow).to(sink).run()
-
   //  source
   //    .via(parseFlow)
-  //    .grouped(10000)
-  //    .runWith(Sink.head)
-  //    .map(e => println(e))
+  //    .via(parsedInputAddressFlow)
+  //    .via(censusFlow)
+  //    .to(sink).run()
 
-  //source.via(parseFlow).via(geocodeFlow).to(sink).run()
+  val sink1 = Sink.foreach(println)
+  val sink2 = Sink.foreach(println)
 
-  // source ~> parseFlow ~> geocodeFlow ~> sink
+  val g = FlowGraph.closed() { implicit builder: FlowGraph.Builder[Unit] =>
+    import FlowGraph.Implicits._
 
-  //  val g = FlowGraph {
-  //
-  //  }
+    val broadcast = builder.add(Broadcast[String](2))
+    val merge = builder.add(Merge[BatchGeocodeResult](2))
 
-  //source.runWith(sink)
+    source ~> broadcast ~> parseFlow ~> parsedInputAddressFlow ~> censusFlow ~> merge ~> sink
+    broadcast ~> addressPointsFlow ~> merge
+
+  }
+
+  g.run()
 
 }

--- a/geocoder/src/main/scala/grasshopper/geocoder/batch/TestBatch.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/batch/TestBatch.scala
@@ -3,7 +3,7 @@ package grasshopper.geocoder.batch
 import akka.actor.ActorSystem
 import akka.stream.Supervision.Decider
 import akka.stream.scaladsl._
-import akka.stream.{ ActorFlowMaterializer, ActorFlowMaterializerSettings, Supervision }
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings, Supervision }
 import grasshopper.geocoder.api.GeocodeFlows
 
 import scala.concurrent.ExecutionContext
@@ -17,8 +17,8 @@ object TestBatch extends App {
   }
 
   implicit val system = ActorSystem("sys")
-  implicit val mat = ActorFlowMaterializer(
-    ActorFlowMaterializerSettings(system)
+  implicit val mat = ActorMaterializer(
+    ActorMaterializerSettings(system)
       .withSupervisionStrategy(decider)
   )
   implicit val ec: ExecutionContext = system.dispatcher
@@ -36,5 +36,4 @@ object TestBatch extends App {
   source2
     .via(GeocodeFlows.geocode)
     .to(Sink.foreach(println)).run()
-
 }

--- a/geocoder/src/main/scala/grasshopper/geocoder/model/BatchGeocodeResult.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/model/BatchGeocodeResult.scala
@@ -1,5 +1,9 @@
 package grasshopper.geocoder.model
 
 sealed trait BatchGeocodeResult
-case class AddressPointsGeocodeBatchResult(input: String, latitude: Double, longitude: Double) extends BatchGeocodeResult
-case class CensusGeocodeBatchResult(input: String, latitude: Double, longitude: Double) extends BatchGeocodeResult
+case class AddressPointsGeocodeBatchResult(input: String, latitude: Double, longitude: Double) extends BatchGeocodeResult {
+  def toCsv = s"${input},${latitude},${longitude}\n"
+}
+case class CensusGeocodeBatchResult(input: String, latitude: Double, longitude: Double) extends BatchGeocodeResult {
+  def toCsv = s"${input},${latitude},${longitude}\n"
+}

--- a/geocoder/src/main/scala/grasshopper/geocoder/model/BatchGeocodeResult.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/model/BatchGeocodeResult.scala
@@ -1,0 +1,5 @@
+package grasshopper.geocoder.model
+
+sealed trait BatchGeocodeResult
+case class AddressPointsGeocodeBatchResult(input: String, latitude: Double, longitude: Double) extends BatchGeocodeResult
+case class CensusGeocodeBatchResult(input: String, latitude: Double, longitude: Double) extends BatchGeocodeResult

--- a/geocoder/src/main/scala/grasshopper/geocoder/model/ParsedInputBatchAddress.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/model/ParsedInputBatchAddress.scala
@@ -1,0 +1,5 @@
+//package grasshopper.geocoder.model
+//
+//import grasshopper.client.census.model.ParsedInputAddress
+//
+//case class ParsedInputBatchAddress(input: String, parsedInputAddress: ParsedInputAddress)

--- a/geocoder/src/main/scala/grasshopper/geocoder/model/ParsedInputBatchAddress.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/model/ParsedInputBatchAddress.scala
@@ -1,5 +1,0 @@
-//package grasshopper.geocoder.model
-//
-//import grasshopper.client.census.model.ParsedInputAddress
-//
-//case class ParsedInputBatchAddress(input: String, parsedInputAddress: ParsedInputAddress)

--- a/geocoder/src/main/scala/grasshopper/geocoder/model/ParsedOutputBatchAddress.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/model/ParsedOutputBatchAddress.scala
@@ -1,0 +1,5 @@
+package grasshopper.geocoder.model
+
+import grasshopper.client.census.model.ParsedInputAddress
+
+case class ParsedOutputBatchAddress(input: String, parsed: ParsedInputAddress)

--- a/geocoder/src/main/scala/grasshopper/geocoder/protocol/GrasshopperJsonProtocol.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/protocol/GrasshopperJsonProtocol.scala
@@ -9,4 +9,6 @@ import grasshopper.geocoder.model._
 trait GrasshopperJsonProtocol extends ClientJsonProtocol with AddressPointsJsonProtocol with CensusJsonProtocol with ParserJsonProtocol {
   implicit val geocodeResultFormat = jsonFormat4(GeocodeResult.apply)
   implicit val geocodeStatusFormat = jsonFormat3(GeocodeStatus.apply)
+  implicit val addressPointsGeocodeBatchResultFormat = jsonFormat3(AddressPointsGeocodeBatchResult.apply)
+  implicit val censusGeocodeBatchResultFormat = jsonFormat3(CensusGeocodeBatchResult.apply)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,25 +7,27 @@ object Dependencies {
     "Sonatype releases" at "https://oss.sonatype.org/content/repositories/releases"
   )
 
-  val akkaActor        = "com.typesafe.akka"          %% "akka-actor"                           % Version.akka
-  val akkaStreams      = "com.typesafe.akka"          %% "akka-stream-experimental"             % Version.akkaStreams
-  val akkaHttpCore     = "com.typesafe.akka"          %% "akka-http-core-experimental"          % Version.akkaStreams
-  val akkaHttp         = "com.typesafe.akka"          %% "akka-http-experimental"               % Version.akkaStreams
-  val akkaHttpJson     = "com.typesafe.akka"          %% "akka-http-spray-json-experimental"    % Version.akkaStreams
-  val akkaHttpTestkit  = "com.typesafe.akka"          %% "akka-http-testkit-experimental"       % Version.akkaStreams % "test"
-  val logback         = "ch.qos.logback"              % "logback-classic"                      % Version.logback
-  val scalaLogging    = "com.typesafe.scala-logging" %% "scala-logging"                        % Version.scalaLogging
+  val akkaActor          = "com.typesafe.akka"          %% "akka-actor"                           % Version.akka
+  val akkaTestKit        = "com.typesafe.akka"          %% "akka-testkit"                         % Version.akka % "test"
+  val akkaStreams        = "com.typesafe.akka"          %% "akka-stream-experimental"             % Version.akkaStreams
+  val akkaStreamsTestkit = "com.typesafe.akka"          %% "akka-stream-testkit-experimental"     % Version.akkaStreams % "test"
+  val akkaHttpCore       = "com.typesafe.akka"          %% "akka-http-core-experimental"          % Version.akkaStreams
+  val akkaHttp           = "com.typesafe.akka"          %% "akka-http-experimental"               % Version.akkaStreams
+  val akkaHttpJson       = "com.typesafe.akka"          %% "akka-http-spray-json-experimental"    % Version.akkaStreams
+  val akkaHttpTestkit    = "com.typesafe.akka"          %% "akka-http-testkit-experimental"       % Version.akkaStreams % "test"
+  val logback            = "ch.qos.logback"              % "logback-classic"                      % Version.logback
+  val scalaLogging       = "com.typesafe.scala-logging" %% "scala-logging"                        % Version.scalaLogging
 
-  val scalaTest        = "org.scalatest"              %% "scalatest"                            % Version.scalaTest   % "it, test"
-  val scalaCheck       = "org.scalacheck"             %% "scalacheck"                           % Version.scalaCheck  % "it, test"
+  val scalaTest          = "org.scalatest"              %% "scalatest"                            % Version.scalaTest   % "it, test"
+  val scalaCheck         = "org.scalacheck"             %% "scalacheck"                           % Version.scalaCheck  % "it, test"
 
-  val es               = "org.elasticsearch"           % "elasticsearch"                        % Version.elasticsearch
+  val es                 = "org.elasticsearch"           % "elasticsearch"                        % Version.elasticsearch
 
-  val scaleGeoJson     = "com.github.jmarin"          %% "scale-geojson"                        % Version.scale
+  val scaleGeoJson       = "com.github.jmarin"          %% "scale-geojson"                        % Version.scale
 
-  val async            = "org.scala-lang.modules"     %% "scala-async"                          % Version.async
+  val async              = "org.scala-lang.modules"     %% "scala-async"                          % Version.async
 
-  val metricsJvm       = "io.dropwizard.metrics"       % "metrics-jvm"                          % Version.metrics
-  val influxDbReporter = "net.alchim31"                % "metrics-influxdb"                     % Version.influxdbReporter
-  val metrics          = "nl.grons"                   %% "metrics-scala"                        % Version.metricsScala excludeAll(ExclusionRule(organization = "com.typesafe.akka"))
+  val metricsJvm         = "io.dropwizard.metrics"       % "metrics-jvm"                          % Version.metrics
+  val influxDbReporter   = "net.alchim31"                % "metrics-influxdb"                     % Version.influxdbReporter
+  val metrics            = "nl.grons"                   %% "metrics-scala"                        % Version.metricsScala excludeAll(ExclusionRule(organization = "com.typesafe.akka"))
 }

--- a/project/GrasshopperBuild.scala
+++ b/project/GrasshopperBuild.scala
@@ -33,7 +33,7 @@ object GrasshopperBuild extends Build {
 
   val commonDeps = Seq(logback, scalaLogging, scalaTest, scalaCheck)
 
-  val akkaDeps = commonDeps ++ Seq(akkaActor, akkaStreams)
+  val akkaDeps = commonDeps ++ Seq(akkaActor, akkaStreams, akkaTestKit, akkaStreamsTestkit)
 
   val jsonDeps = commonDeps ++ Seq(akkaHttpJson)
 

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -3,7 +3,7 @@ object Version {
   val logback          = "1.1.2"
   val scalaLogging     = "3.1.0"
   val akka             = "2.3.11"
-  val akkaStreams      = "1.0-RC3"
+  val akkaStreams      = "1.0-RC4"
   val scalaTest        = "2.2.1"
   val scalaCheck       = "1.12.1"
   val elasticsearch    = "1.4.2"


### PR DESCRIPTION
Allows batch geocoding on /geocode, by issuing a POST request with a file containing one address string per line (encoding multipart/form-data). The batch endpoint geocodes the addresses in parallel and then decides which result to return (i.e. addresspoints > census). A text/csv response with the results is offered to the client (this should trigger download of a file on modern browsers).
This PR also updates the project to Akka Streams 1.0-RC4 which required minimum refactoring, and improves the way the client project treats strings by assuming that the HTTP encoding is done server side, to allow non browser clients to just send raw strings (i.e. without separating components of an address with "+")
