### PR TITLE
Remove replaceAll, fails encoding

### DIFF
--- a/geocoder/src/main/scala/grasshopper/geocoder/api/Service.scala
+++ b/geocoder/src/main/scala/grasshopper/geocoder/api/Service.scala
@@ -104,7 +104,7 @@ trait Service extends GrasshopperJsonProtocol with ClientJsonProtocol {
             val parsedAddress = addr.right.getOrElse(ParsedAddress.empty)
             val parsedInputAddress = ParsedInputAddress(
               parsedAddress.parts.addressNumber.toInt,
-              parsedAddress.parts.streetName.replaceAll(" ", "+"),
+              parsedAddress.parts.streetName,
               parsedAddress.parts.zip,
               parsedAddress.parts.state
             )


### PR DESCRIPTION
The following request should work but is failing due to improper encoding of the street name

http://localhost:8080/geocode/3300 Holma Rd Harmony ME 04224
