### PR TITLE
Adds logstash-output-syslog plugin

### DIFF
--- a/docker/logstash/Dockerfile
+++ b/docker/logstash/Dockerfile
@@ -2,5 +2,7 @@ FROM logstash:1.5.4-1
 
 ADD grasshopper.conf /opt/
 
+RUN /opt/logstash/bin/plugin install --version 0.1.4 logstash-output-syslog
+
 CMD ["logstash", "-f", "/opt/grasshopper.conf"]
 


### PR DESCRIPTION
Adds the latest version of the [logstash-output-syslog](https://github.com/logstash-plugins/logstash-output-syslog) Logstash plugin, which is not included in the [Official Logstash Image](https://hub.docker.com/_/logstash/).
