### PR TITLE
Properly encode state synonym input, add integration test (fixes #154)

### DIFF
--- a/client/src/it/scala/grasshopper/client/census/CensusClientSpec.scala
+++ b/client/src/it/scala/grasshopper/client/census/CensusClientSpec.scala
@@ -36,4 +36,21 @@ class CensusClientSpec extends FlatSpec with MustMatchers {
     }
   }
 
+  it should "respond with address with synonym in State definition" in {
+    val parsedAddress = ParsedInputAddress(456, "Central Ave", "11516", "New York")
+    val maybeAddress = Await.result(CensusClient.geocode(parsedAddress), 10.seconds)
+    maybeAddress match {
+      case Right(result) =>
+        result.status mustBe "OK"
+        val features = result.features
+        features.size mustBe 1
+        val f = features(0)
+        val address = f.values.getOrElse("FULLNAME", "")
+        address mustBe "Central Ave"
+      case Left(b) =>
+        b.desc mustBe "503 Service Unavailable"
+        fail("SERVICE_UNAVAILABLE")
+    }
+  }
+
 }

--- a/client/src/main/scala/grasshopper/client/census/CensusClient.scala
+++ b/client/src/main/scala/grasshopper/client/census/CensusClient.scala
@@ -33,7 +33,8 @@ object CensusClient extends ServiceClient with CensusJsonProtocol {
   def geocode(address: ParsedInputAddress): Future[Either[ResponseError, CensusResult]] = {
     implicit val ec: ExecutionContext = system.dispatcher
     val streetName = URLEncoder.encode(address.streetName, "UTF-8")
-    val url = s"/census/addrfeat?number=${address.number}&streetName=${streetName}&zipCode=${address.zipCode}&state=${address.state}"
+    val state = URLEncoder.encode(address.state, "UTF-8")
+    val url = s"/census/addrfeat?number=${address.number}&streetName=${streetName}&zipCode=${address.zipCode}&state=${state}"
     sendGetRequest(url).flatMap { response =>
       response.status match {
         case OK => Unmarshal(response.entity).to[CensusResult].map(Right(_))


### PR DESCRIPTION
Fixes errors produced when passing in state definitions such as `New York`, which were not encoded correctly. The integration test checks for synonyms working with this value passed in
