### PR TITLE
update volume path

### DIFF
--- a/census/src/test/scala/grasshopper/census/search/AddressInterpolatorSpec.scala
+++ b/census/src/test/scala/grasshopper/census/search/AddressInterpolatorSpec.scala
@@ -3,7 +3,7 @@ package grasshopper.census.search
 import geometry.Point
 import grasshopper.census.model.AddressRange
 import grasshopper.census.util.TestData._
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.scalatest.{ FlatSpec, MustMatchers }
 
 class AddressInterpolatorSpec extends FlatSpec with MustMatchers {
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,4 +54,4 @@ ui:
   links:
     - geocoder
   volumes:
-    - ../grasshopper-ui/dist:/opt/grasshopper-ui/
+    - ../grasshopper-ui/dist:/usr/src/app/dist/


### PR DESCRIPTION
The volume path in `docker-compose.yml` was never updated since [we made the change to the directory](https://github.com/cfpb/grasshopper-ui/commit/d91c13a7b562d76071ed8dfb96e82d5ee818b421) in the UI Dockerfile.

I have no idea how the change to `census/src/test/scala/grasshopper/census/search/AddressInterpolatorSpec.scala` happened. I have never touched that file.

@jmarin @hkeeler 
