### PR TITLE
Adds test-harness Compose setup

### DIFF
--- a/docker-compose-test-harness.yaml
+++ b/docker-compose-test-harness.yaml
@@ -1,0 +1,66 @@
+# production compose
+# extend from docker-compose-common.yml
+test_harness:
+  build: test-harness
+  volumes:
+    # FIXME: This should be a configurable using envvars
+    - ../grasshopper-qa:/opt/grasshopper-qa
+  environment: &grasshopper_envvars
+    ELASTICSEARCH_CLUSTER: elasticsearch # default.  
+    ELASTICSEARCH_HOST: elasticsearch
+    ELASTICSEARCH_PORT: "9300" # MUST set to override Compose-generated envvar of the same name
+    GRASSHOPPER_PARSER_HOST: parser
+    HMDA_GEO_HOST: hmda_geo_api
+    HMDA_GEO_PORT: "8084" # MUST set to override Compose-generate envvar of the same name
+  links:
+    - hmda_geo_api
+    - parser
+    - elasticsearch
+  entrypoint: "java -jar /opt/grasshopper-test_harness.jar"
+  command: "/opt/grasshopper-qa/data/in.csv /opt/grasshopper-qa/data/out.csv"
+
+# The geocoder is not actually a dependency of test_harness, but it
+# it is handy to have running for comparison against test_harness.
+geocoder:
+  extends:
+    file: docker-compose-common.yml
+    service: geocoder
+  links:
+    - parser
+    - elasticsearch
+  environment: *grasshopper_envvars
+
+parser:
+  extends:
+    file: docker-compose-common.yml
+    service: parser
+
+loader:
+  extends:
+    file: docker-compose-common.yml
+    service: loader
+  links:
+    - elasticsearch
+
+elasticsearch:
+  extends:
+    file: docker-compose-common.yml
+    service: elasticsearch
+  ports:
+    - "9200:9200" # Expose web api for testing
+
+hmda_geo_postgis:
+  build: ../hmda-geo/docker/postgis-tracts
+  ports:
+    - "5432:5432"
+
+hmda_geo_api:
+  build: ../hmda-geo/api
+  ports:
+    - "8084:8084"
+  environment:
+    PG_HOST: hmda_geo_postgis
+    PG_USER: docker
+    PG_PASSWORD: docker
+  links:
+    - hmda_geo_postgis


### PR DESCRIPTION
Here's a Docker Compose setup for building and running `test-harness` and **all** its dependencies.  This setup works..._mostly_.  However, there have been several inconsistent errors while loading data, primarily related to network and file access.  I've done a full rebuild and re-load 3x, and I've encountered similar issues, but not always during the same point in the loading process.

It is unclear what's causing this.  I'm putting this PR up now so others can try it on their machines and see if they encounter the same issues.

In order to run this, you will need more storage than the default Docker Machine Virtualbox image comes with.  At the bare minimum you need to increase the disk space, but I've also bumped up RAM and CPUs.  It looks like this:

```
docker-machine create --driver virtualbox \
--virtualbox-memory 4096 \
--virtualbox-cpu-count 4 \
--virtualbox-disk-size 102400 \
docker-dev
```

Once you've created the new image, you're ready to launch.  However, before you do, make sure you have the latest version of all dependent projects, and that they're checked out into the same directory as your `grasshopper` project.
- grasshopper-loader
- grasshopper-parser
- hmda-geo

To launch the stack.  This will take _a while_ as it has to build the `hmda-geo` Docker images, which include a pretty big data load.

```
docker-compose -f docker-compose-test-harness.yaml up
```

Load the data:

```
# Address points
docker-compose -f docker-compose-test-harness.yaml run loader ./index.js -f data.json

# TIGER lines
docker-compose -f docker-compose-test-harness.yaml run loader ./tiger.js
```

Give it a whirl, and let me know how it goes.
