### PR TITLE
Switches geocoder API port from 31010 to 10001

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ USER daemon
 
 ENTRYPOINT ["java", "-jar", "/opt/grasshopper.jar"]
 
-EXPOSE 31010
+EXPOSE 10001 
 
 COPY target/scala-2.11/grasshopper.jar /opt/grasshopper.jar

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This will retrieve all necessary dependencies, compile Scala source, and start a
 
         > ~re-start
 
-1. Confirm service is up by browsing to http://localhost:31010.
+1. Confirm service is up by browsing to http://localhost:10001.
 
 ### Docker
 
@@ -132,7 +132,7 @@ a VM to run Docker.  Below are the steps for setting up a VirtualBox-based VM us
 
     | Container       | URL                             |
     |-----------------|---------------------------------|
-    | `geocoder`      | http://{{docker-host-ip}}:31010 |
+    | `geocoder`      | http://{{docker-host-ip}}:10001 |
     | `parser`        | http://{{docker-host-ip}}:5000  |
     | `ui`            | http://{{docker-host-ip}}       |
     | `elasticsearch` | http://{{docker-host-ip}}:9200  |

--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -1,7 +1,7 @@
 geocoder:
   build: .
   ports:
-    - "31010:31010"
+    - "10001:10001"
   environment:
     ELASTICSEARCH_HOST: elasticsearch
     # NOTE: Official ES image has a ELASTICSEARCH_PORT envvar,

--- a/docs/geocoder_public_api_spec.md
+++ b/docs/geocoder_public_api_spec.md
@@ -107,7 +107,7 @@ One or more features may be returned, with the `source` field indicating what se
 The request must send a file with one address string per line as `multipart/form-data`. For instance, using `curl`:
 
 ```
-curl -v -F upload=@batch_addresses.csv http://localhost:31010/geocode
+curl -v -F upload=@batch_addresses.csv http://localhost:10001/geocode
 ```
 
 This endpoint will geocode the addresses in parallel and choose the best option from the available geocoders.

--- a/geocoder/src/main/resources/application.conf
+++ b/geocoder/src/main/resources/application.conf
@@ -15,7 +15,7 @@ grasshopper {
     http {
       interface = "0.0.0.0"
       interface = ${?GEOCODER_HTTP_HOST}
-      port = 31010
+      port = 10001 
       port = ${?GEOCODER_HTTP_PORT}
     }
     elasticsearch {

--- a/geocoder/src/main/resources/webapp/js/metrics.js
+++ b/geocoder/src/main/resources/webapp/js/metrics.js
@@ -1,4 +1,4 @@
-var ws = new WebSocket("ws://localhost:31010/metrics-ws");
+var ws = new WebSocket("ws://localhost:10001/metrics-ws");
 
 var geocoded = 0;
 


### PR DESCRIPTION
As mentioned on https://github.com/cfpb/hmda-platform-ui/issues/202#issuecomment-242519678, and similar to https://github.com/cfpb/hmda-platform/pull/536, get the port numbers lined up with the `grasshopper-ui` Nginx setup. 
